### PR TITLE
Firefox rejecting xpi v0.8 install as "corrupt"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Getting started (firefox from v57)
 1. Click this link to start installing.
-https://github.com/buggyj/savetiddlers/releases/download/0.8/save_tiddlers-0.8-an.fx.xpi
+https://github.com/buggyj/savetiddlers/releases/download/0.11/save_tiddlers-0.11-fx.xpi
 2. **Create a subdir called tiddlywikilocations** in the folder firefox uses for downloads (you can see and change this location in firefoxes prefrences). 
 3. Download a tiddlywiki from http://tiddlywiki.com/, and **place in that subdir**, or copy your tiddlywikis there.
 4.  The user prefs need to look like similar to this ( If you type 'about:preferences' in the browsers address bar it will take you to the prefs page):

--- a/extension/contentscript.js
+++ b/extension/contentscript.js
@@ -59,7 +59,7 @@ function injectMessageBox(doc) {
 	doc = document;
 	if (isTiddlyWikiClassic(doc)) {
 		s = document.createElement('script');
-		s.src = chrome.extension.getURL('script.js');
+		s.src = chrome.runtime.getURL('script.js');
 		(document.head||document.documentElement).appendChild(s);
 		s.onload = function() {
 			s.parentNode.removeChild(s);

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -2,10 +2,10 @@
     "name": "Save Tiddlers",
     "version": "0.11",
     "manifest_version": 2,
-    "applications": {
+    "browser_specific_settings": {
         "gecko": {
-            "id": "random201709301147@buggyjef.uk",
-            "strict_min_version": "56.0"
+          "id": "random201709301147@buggyjef.uk",
+          "strict_min_version": "58.0"
         }
     }, 
      "browser_action": {


### PR DESCRIPTION
## Contents

- Updated xpi link for Firefox users in readme
- Fixed 3 add-on warnings from Mozilla

## Background

I went to install the readme-recommended v0.8 xpi recently only to find that Firefox now rejects the xpi install as "corrupt".  At this point, not realizing that there was a newer version which I could try installing, it seemed like the 0.8 version needed to be validated still by Mozilla.  When submitting the extension to the Mozilla Add-On Validator, I received a couple validation warnings (included below) which I fixed and submitted only to find that the extension had already been submitted.  At this point I realized that you had probably updated it already and I returned to the releases section and installed the "Chrome" version.  That installed without any issues and appears to be working great.

## Summary

I think the fix is to recommend that Firefox users install the newest version, unless you had some reason why you were not doing that before.  I updated the link in the readme and I included the validation fixes I had done since you'll probably need to make those changes eventually.

### Validation Warnings

> **Use "browser_specific_settings" instead of "applications".**
> Warning: The "applications" property in the manifest is deprecated and will no longer be accepted in Manifest Version 3 and above.
> [Location] manifest.json

> **Manifest key not supported by the specified minimum Firefox for Android version**
> Warning: "strict_min_version" requires Firefox for Android 58, which was released before version 79 introduced support for "browser_action.default_icon".
> [Location] manifest.json

> **extension.getURL is deprecated**
> Warning: This API has been deprecated by Firefox.
> [Location] contentscript.js line 62 column 11